### PR TITLE
Fix for infinite loop bug that can crash chrome. 

### DIFF
--- a/src/ReduxedStorage.ts
+++ b/src/ReduxedStorage.ts
@@ -79,7 +79,7 @@ export default class ReduxedStorage<
         mergeOrReplace(this.state, state) : mergeOrReplace(state, this.state);
       !newTime && isEqual(newState, this.state) ||
         ( this._setState(newState, timestamp), this._renewStore() );
-      newTime && isEqual(newState, state) ||
+      if (newTime && !isEqual(newState, state))
         this._send2Storage();
       this._callListeners();
     });


### PR DESCRIPTION
**Problem**
Given two concurrent dispatches into the redux store, across different threads, we can fall into an infinite loop of saving competing states. `_send2Storage` saves State A, `subscribe` responds to a save of State B, saves State B, and then we go back to A - until Chrome crashes. 

I've set up a repo where the problem can be replicated:
https://github.com/vladloom/chrome-extension-reduxed-storage

Here's a Demo of the crash in action:
https://www.loom.com/share/35a654ae83b540d4953c4aa89f1485c4

**Error condition**: 
newTime = false
isEqual = false


**Before**:

```
newTime && isEqual(newState, state) ||
  this._send2Storage();
```

| newTime | isEqual(newState, state)       |                                            |.                               |
|----------|-----------------------------|--------------------------|-------------------|
| false        | false                                        | this._send2Storage();      | Error condition      |
| false        | true                                        | this._send2Storage();      | Already equal —> no need to write |
| true.        | false                                        | this._send2Storage();      |                                |
| true         |  true                                        | no-op                                 |                                |
 

**After**:
```
  if(newTime && !isEqual(newState, state)) {
    this._send2Storage();
  }
```


| newTime | isEqual(newState, state)       |                                            |                        
|----------|-----------------------------|--------------------------|
| false        | false                                        | no-op                                 | 
| false        | true                                        | no-op                                 |
| true         | false                                        | this._send2Storage();      |
| true         |  true                                        | no-op                                 |  